### PR TITLE
fix: Broken Form Prompt Translations in Production Builds

### DIFF
--- a/packages/@svelte-in-motion-builtin-extensions/src/extensions/commands.ts
+++ b/packages/@svelte-in-motion-builtin-extensions/src/extensions/commands.ts
@@ -113,6 +113,7 @@ export const EXTENSION_COMMANDS = define_extension({
                     await prompts.prompt_form<any>({
                         is_dismissible: true,
 
+                        namespace: command.identifier,
                         type: command.type,
                     })
                 ).model;

--- a/packages/@svelte-in-motion-builtin-extensions/src/extensions/export.ts
+++ b/packages/@svelte-in-motion-builtin-extensions/src/extensions/export.ts
@@ -83,6 +83,7 @@ export const EXTENSION_EXPORT = define_extension({
                 await prompts.prompt_form<FramesExport>({
                     is_dismissible: true,
 
+                    namespace: "frames_export",
                     type: typeOf<FramesExport>(),
                     model: {
                         // TODO: Make prompt configuration dynamic to support this as runtime validation
@@ -161,6 +162,7 @@ export const EXTENSION_EXPORT = define_extension({
                 await prompts.prompt_form<VideoExport>({
                     is_dismissible: true,
 
+                    namespace: "video_export",
                     type: typeOf<VideoExport>(),
                     model: {
                         // TODO: Make prompt configuration dynamic to support this as runtime validation

--- a/packages/@svelte-in-motion-builtin-extensions/src/extensions/workspace.ts
+++ b/packages/@svelte-in-motion-builtin-extensions/src/extensions/workspace.ts
@@ -106,6 +106,7 @@ export const EXTENSION_WORKSPACE = define_extension({
                 await prompts.prompt_form<WorkspaceNew>({
                     is_dismissible: true,
 
+                    namespace: "workspace_new",
                     type: typeOf<WorkspaceNew>(),
                 })
             ).model;
@@ -170,6 +171,7 @@ export const EXTENSION_WORKSPACE = define_extension({
                 await prompts.prompt_form<WorkspaceNew>({
                     is_dismissible: true,
 
+                    namespace: "workspace_new",
                     type: typeOf<WorkspaceNew>(),
                 })
             ).model;
@@ -187,6 +189,7 @@ export const EXTENSION_WORKSPACE = define_extension({
                     await prompts.prompt_form<any>({
                         is_dismissible: true,
 
+                        namespace: template.identifier,
                         type: template.type,
                     })
                 ).model;

--- a/packages/@svelte-in-motion-editor/src/components/form/FormBoolean.svelte
+++ b/packages/@svelte-in-motion-editor/src/components/form/FormBoolean.svelte
@@ -8,16 +8,17 @@
 
     const {translations} = CONTEXT_APP.get()!;
 
-    export let type: TypeBoolean;
+    export let namespace: string;
     export let signature: TypePropertySignature;
+    export let type: TypeBoolean;
     export let value: boolean = false;
 
-    $: form_identifier = `prompts-${format_dash_case(
-        signature.parent.typeName!
-    )}-${format_dash_case(signature.name.toString())}`;
-    $: translation_identifier = `prompts-${format_snake_case(
-        signature.parent.typeName!
-    )}-${format_snake_case(signature.name.toString())}`;
+    $: form_identifier = `prompts-${format_dash_case(namespace)}-${format_dash_case(
+        signature.name.toString()
+    )}`;
+    $: translation_identifier = `prompts-${format_snake_case(namespace)}-${format_snake_case(
+        signature.name.toString()
+    )}`;
 
     $: description = `${translation_identifier}-description`;
     $: label = `${translation_identifier}-label`;

--- a/packages/@svelte-in-motion-editor/src/components/form/FormNumber.svelte
+++ b/packages/@svelte-in-motion-editor/src/components/form/FormNumber.svelte
@@ -13,16 +13,17 @@
 
     const {translations} = CONTEXT_APP.get()!;
 
-    export let type: TypeNumber;
+    export let namespace: string;
     export let signature: TypePropertySignature;
+    export let type: TypeNumber;
     export let value: number = 0;
 
-    $: form_identifier = `prompts-${format_dash_case(
-        signature.parent.typeName!
-    )}-${format_dash_case(signature.name.toString())}`;
-    $: translation_identifier = `prompts-${format_snake_case(
-        signature.parent.typeName!
-    )}-${format_snake_case(signature.name.toString())}`;
+    $: form_identifier = `prompts-${format_dash_case(namespace)}-${format_dash_case(
+        signature.name.toString()
+    )}`;
+    $: translation_identifier = `prompts-${format_snake_case(namespace)}-${format_snake_case(
+        signature.name.toString()
+    )}`;
 
     $: description = `${translation_identifier}-description`;
     $: label = `${translation_identifier}-label`;

--- a/packages/@svelte-in-motion-editor/src/components/form/FormRender.svelte
+++ b/packages/@svelte-in-motion-editor/src/components/form/FormRender.svelte
@@ -83,6 +83,7 @@
 
     type IFormModel = Record<string, any>;
 
+    export let namespace: string;
     export let type: IFormType;
 
     if (type.kind !== ReflectionKind.objectLiteral) {
@@ -122,6 +123,7 @@
         <svelte:component
             this={Component}
             type={signature.type}
+            {namespace}
             {signature}
             bind:value={model[signature.name.toString()]}
         />

--- a/packages/@svelte-in-motion-editor/src/components/form/FormString.svelte
+++ b/packages/@svelte-in-motion-editor/src/components/form/FormString.svelte
@@ -13,16 +13,17 @@
 
     const {translations} = CONTEXT_APP.get()!;
 
-    export let type: TypeString;
+    export let namespace: string;
     export let signature: TypePropertySignature;
+    export let type: TypeString;
     export let value: string = "";
 
-    $: form_identifier = `prompts-${format_dash_case(
-        signature.parent.typeName!
-    )}-${format_dash_case(signature.name.toString())}`;
-    $: translation_identifier = `prompts-${format_snake_case(
-        signature.parent.typeName!
-    )}-${format_snake_case(signature.name.toString())}`;
+    $: form_identifier = `prompts-${format_dash_case(namespace)}-${format_dash_case(
+        signature.name.toString()
+    )}`;
+    $: translation_identifier = `prompts-${format_snake_case(namespace)}-${format_snake_case(
+        signature.name.toString()
+    )}`;
 
     $: description = `${translation_identifier}-description`;
     $: label = `${translation_identifier}-label`;

--- a/packages/@svelte-in-motion-editor/src/components/form/FormUnion.svelte
+++ b/packages/@svelte-in-motion-editor/src/components/form/FormUnion.svelte
@@ -35,8 +35,6 @@
             type.literal as string
         )}-label`;
 
-        console.log({type_identifier});
-
         if ($translations.has(type_identifier)) {
             return {
                 text: $translations.format(type_identifier),

--- a/packages/@svelte-in-motion-editor/src/components/form/FormUnion.svelte
+++ b/packages/@svelte-in-motion-editor/src/components/form/FormUnion.svelte
@@ -12,16 +12,17 @@
 
     const {translations} = CONTEXT_APP.get()!;
 
-    export let type: TypeUnion;
+    export let namespace: string;
     export let signature: TypePropertySignature;
+    export let type: TypeUnion;
     export let value: string = "";
 
-    $: form_identifier = `prompts-${format_dash_case(
-        signature.parent.typeName!
-    )}-${format_dash_case(signature.name.toString())}`;
-    $: translation_identifier = `prompts-${format_snake_case(
-        signature.parent.typeName!
-    )}-${format_snake_case(signature.name.toString())}`;
+    $: form_identifier = `prompts-${format_dash_case(namespace)}-${format_dash_case(
+        signature.name.toString()
+    )}`;
+    $: translation_identifier = `prompts-${format_snake_case(namespace)}-${format_snake_case(
+        signature.name.toString()
+    )}`;
 
     $: description = `${translation_identifier}-description`;
     $: label = `${translation_identifier}-label`;
@@ -33,6 +34,8 @@
         const type_identifier = `${translation_identifier}-${format_dash_case(
             type.literal as string
         )}-label`;
+
+        console.log({type_identifier});
 
         if ($translations.has(type_identifier)) {
             return {

--- a/packages/@svelte-in-motion-editor/src/components/prompts/FormPrompt.svelte
+++ b/packages/@svelte-in-motion-editor/src/components/prompts/FormPrompt.svelte
@@ -23,6 +23,7 @@
     const dispatch = createEventDispatcher();
 
     export let model: any;
+    export let namespace: string;
     export let type: TypeObjectLiteral;
 
     function on_dismiss_click(event: MouseEvent): void {
@@ -48,7 +49,7 @@
 <Card.Section>
     <form on:submit={on_submit}>
         <Stack.Container spacing="small">
-            <FormRender {type} bind:model />
+            <FormRender {namespace} {type} bind:model />
         </Stack.Container>
 
         <input type="submit" data-hidden />

--- a/packages/@svelte-in-motion-editor/src/components/prompts/FormPrompt.svelte
+++ b/packages/@svelte-in-motion-editor/src/components/prompts/FormPrompt.svelte
@@ -41,7 +41,7 @@
         });
     }
 
-    $: translation_identifier = `prompts-${format_snake_case(type.typeName!)}`;
+    $: translation_identifier = `prompts-${format_snake_case(namespace)}`;
 
     $: is_valid = validates(model, type);
 </script>

--- a/packages/@svelte-in-motion-editor/src/lib/stores/prompts.ts
+++ b/packages/@svelte-in-motion-editor/src/lib/stores/prompts.ts
@@ -37,6 +37,8 @@ export interface IFormPromptProps<T> {
 
     model?: Partial<ClassProperties<T>>;
 
+    namespace: string;
+
     type: Type;
 }
 

--- a/packages/@svelte-in-motion-editor/src/lib/stores/prompts.ts
+++ b/packages/@svelte-in-motion-editor/src/lib/stores/prompts.ts
@@ -197,7 +197,7 @@ export function prompts(): IPromptsStore {
                 Component: FormPrompt,
 
                 is_dismissible: props.is_dismissible,
-                title: `prompts-${format_snake_case(props.type.typeName!)}-label`,
+                title: `prompts-${format_snake_case(props.namespace)}-label`,
                 props,
             });
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,7 +214,7 @@ importers:
       '@tsconfig/svelte': 2.0.1
       '@types/flexsearch': 0.7.3
       '@types/prismjs': 1.26.0
-      prettier-plugin-svelte: 2.7.0_svelte@3.46.4
+      prettier-plugin-svelte: 2.7.0_prettier@2.7.0+svelte@3.46.4
       svelte: 3.46.4
       svelte-check: 2.4.5_svelte@3.46.4
       svelte-preprocess: 4.10.4_svelte@3.46.4+typescript@4.7.3
@@ -3388,6 +3388,16 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /prettier-plugin-svelte/2.7.0_prettier@2.7.0+svelte@3.46.4:
+    resolution: {integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==}
+    peerDependencies:
+      prettier: ^1.16.4 || ^2.0.0
+      svelte: ^3.2.0
+    dependencies:
+      prettier: 2.7.0
+      svelte: 3.46.4
+    dev: true
+
   /prettier-plugin-svelte/2.7.0_prettier@2.7.0+svelte@3.48.0:
     resolution: {integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==}
     peerDependencies:
@@ -3396,15 +3406,6 @@ packages:
     dependencies:
       prettier: 2.7.0
       svelte: 3.48.0
-    dev: true
-
-  /prettier-plugin-svelte/2.7.0_svelte@3.46.4:
-    resolution: {integrity: sha512-fQhhZICprZot2IqEyoiUYLTRdumULGRvw0o4dzl5jt0jfzVWdGqeYW27QTWAeXhoupEZJULmNoH3ueJwUWFLIA==}
-    peerDependencies:
-      prettier: ^1.16.4 || ^2.0.0
-      svelte: ^3.2.0
-    dependencies:
-      svelte: 3.46.4
     dev: true
 
   /prettier/2.5.1:


### PR DESCRIPTION
# Description

Apparently DeepKit loses some typing information, including interface names in production builds. So we end up with strings like `unknown_type_name:()=>_\u03_a9_workspace_new`. It's unclear why, but as a monkey patch I made all existing usage simply provide the interface's namespace.