### PR TITLE
fix: New Workspace Command using Wrong Template Identifier

### DIFF
--- a/packages/@svelte-in-motion-builtin-extensions/src/extensions/workspace.ts
+++ b/packages/@svelte-in-motion-builtin-extensions/src/extensions/workspace.ts
@@ -115,7 +115,7 @@ export const EXTENSION_WORKSPACE = define_extension({
             throw err;
         }
 
-        render_template(app, result.name, "templates.welcome");
+        render_template(app, result.name, "welcome");
     },
 
     async command_prompt_new_from_template(app: IAppContext) {


### PR DESCRIPTION
# Description

"New Workspace" command was pointing to the old identifier for the welcome template.